### PR TITLE
Fix recursion error if weakref has been cleaned up

### DIFF
--- a/test_asyncio_atexit.py
+++ b/test_asyncio_atexit.py
@@ -75,3 +75,20 @@ def test_unregister(policy):
 
     asyncio_run(test())
     assert not sync_called
+
+
+def test_run_raises(policy):
+    sync_called = False
+
+    def sync_cb():
+        nonlocal sync_called
+        sync_called = True
+
+    async def test():
+        asyncio_atexit.register(sync_cb)
+        1 / 0
+
+    with pytest.raises(ZeroDivisionError):
+        asyncio_run(test())
+
+    assert sync_called


### PR DESCRIPTION
weakref can be unresolved before close is called, e.g. when close is called via `__del__` when asyncio.run is given a coroutine that raises